### PR TITLE
fix: converting bloc status switches to expressions

### DIFF
--- a/lib/blog_detail/view/blog_detail_page.dart
+++ b/lib/blog_detail/view/blog_detail_page.dart
@@ -36,41 +36,34 @@ class BlogDetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<BlogDetailBloc, BlogDetailState>(
-      builder: (context, state) {
-        // Coverage on switch is known issue: https://github.com/dart-lang/sdk/issues/54941
-        // https://github.com/stefanhk31/personal_blog_flutter/issues/43
-        // coverage:ignore-start
-        return switch (state) {
-          // coverage:ignore-end
-          BlogDetailInitial() || BlogDetailLoading() => const Center(
-              child: CircularProgressIndicator(),
-            ),
-          BlogDetailFailure(error: final error) => Center(
-              child: Container(
-                color: Theme.of(context).colorScheme.error,
-                padding: BlogSpacing.allPadding,
-                child: Text(
-                  error.toString(),
-                  style: BlogTextStyles.errorTextStyle.copyWith(
-                    color: Theme.of(context).colorScheme.onError,
-                  ),
+      builder: (context, state) => switch (state) {
+        BlogDetailInitial() || BlogDetailLoading() => const Center(
+            child: CircularProgressIndicator(),
+          ),
+        BlogDetailFailure(error: final error) => Center(
+            child: Container(
+              color: Theme.of(context).colorScheme.error,
+              padding: BlogSpacing.allPadding,
+              child: Text(
+                error.toString(),
+                style: BlogTextStyles.errorTextStyle.copyWith(
+                  color: Theme.of(context).colorScheme.onError,
                 ),
               ),
             ),
-          BlogDetailLoaded(detail: final detail) => BlogDetailContent(
-              authorName:
-                  '${detail.author.firstName} ${detail.author.lastName}',
-              body: detail.body,
-              published: detail.published,
-              slug: detail.slug,
-              title: detail.title,
-              authorImage: detail.author.profileImage,
-              featuredImage: detail.featuredImage,
-              onLinkTap: (url, attributes, element) => context
-                  .read<BlogDetailBloc>()
-                  .add(BlogLinkClicked(url: url ?? '')),
-            )
-        };
+          ),
+        BlogDetailLoaded(detail: final detail) => BlogDetailContent(
+            authorName: '${detail.author.firstName} ${detail.author.lastName}',
+            body: detail.body,
+            published: detail.published,
+            slug: detail.slug,
+            title: detail.title,
+            authorImage: detail.author.profileImage,
+            featuredImage: detail.featuredImage,
+            onLinkTap: (url, attributes, element) => context
+                .read<BlogDetailBloc>()
+                .add(BlogLinkClicked(url: url ?? '')),
+          )
       },
     );
   }

--- a/lib/blog_overview/view/blog_overview_page.dart
+++ b/lib/blog_overview/view/blog_overview_page.dart
@@ -35,31 +35,25 @@ class BlogOverview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<BlogOverviewBloc, BlogOverviewState>(
-      builder: (context, state) {
-        // Coverage on switch is known issue: https://github.com/dart-lang/sdk/issues/54941
-        // https://github.com/stefanhk31/personal_blog_flutter/issues/43
-        // coverage:ignore-start
-        return switch (state) {
-          // coverage:ignore-end
-          BlogOverviewInitial() || BlogOverviewLoading() => const Center(
-              child: CircularProgressIndicator(),
-            ),
-          BlogOverviewFailure(error: final error) => Center(
-              child: Container(
-                color: Theme.of(context).colorScheme.error,
-                padding: BlogSpacing.allPadding,
-                child: Text(
-                  error.toString(),
-                  style: BlogTextStyles.errorTextStyle.copyWith(
-                    color: Theme.of(context).colorScheme.onError,
-                  ),
+      builder: (context, state) => switch (state) {
+        BlogOverviewInitial() || BlogOverviewLoading() => const Center(
+            child: CircularProgressIndicator(),
+          ),
+        BlogOverviewFailure(error: final error) => Center(
+            child: Container(
+              color: Theme.of(context).colorScheme.error,
+              padding: BlogSpacing.allPadding,
+              child: Text(
+                error.toString(),
+                style: BlogTextStyles.errorTextStyle.copyWith(
+                  color: Theme.of(context).colorScheme.onError,
                 ),
               ),
             ),
-          BlogOverviewLoaded(previews: final previews) => _BlogOverviewContent(
-              previews: previews,
-            )
-        };
+          ),
+        BlogOverviewLoaded(previews: final previews) => _BlogOverviewContent(
+            previews: previews,
+          )
       },
     );
   }

--- a/packages/blog_ui/lib/src/theme/blog_theme.dart
+++ b/packages/blog_ui/lib/src/theme/blog_theme.dart
@@ -20,7 +20,7 @@ class BlogTheme {
   /// Color scheme that is used to generate light theme colors.
   static ColorScheme get lightColorScheme => ColorScheme.fromSeed(
         seedColor: BlogColors.seedPurple,
-        background: BlogColors.seedLightBackground,
+        surface: BlogColors.seedLightBackground,
         primary: BlogColors.seedTextPrimaryDark,
         secondary: BlogColors.seedTextSecondaryDark,
       );
@@ -28,7 +28,7 @@ class BlogTheme {
   /// Color scheme that is used to generate dark theme colors.
   static ColorScheme get darkColorScheme => ColorScheme.fromSeed(
         seedColor: BlogColors.seedLightPurple,
-        background: BlogColors.seedDarkBackground,
+        surface: BlogColors.seedDarkBackground,
         primary: BlogColors.seedTextPrimaryLight,
         secondary: BlogColors.seedTextSecondaryLight,
       );

--- a/packages/blog_ui/pubspec.yaml
+++ b/packages/blog_ui/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
       ref: hotfix/incompat-regexp
   google_fonts: ^6.2.1
   html: ^0.15.4
-  intl: ^0.18.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/blog_ui/test/src/theme/blog_theme_test.dart
+++ b/packages/blog_ui/test/src/theme/blog_theme_test.dart
@@ -9,9 +9,9 @@ void main() {
         expect(BlogTheme.lightThemeData.useMaterial3, isTrue);
       });
 
-      test('background color is seedLightBackground', () {
+      test('surface color is seedLightBackground', () {
         expect(
-          BlogTheme.lightThemeData.colorScheme.background,
+          BlogTheme.lightThemeData.colorScheme.surface,
           equals(BlogColors.seedLightBackground),
         );
       });
@@ -43,9 +43,9 @@ void main() {
         expect(BlogTheme.darkThemeData.useMaterial3, isTrue);
       });
 
-      test('background color is seedDarkBackground', () {
+      test('surface color is seedDarkBackground', () {
         expect(
-          BlogTheme.darkThemeData.colorScheme.background,
+          BlogTheme.darkThemeData.colorScheme.surface,
           equals(BlogColors.seedDarkBackground),
         );
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ publish_to: none
 
 environment:
   sdk: "^3.3.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   bloc: ^8.1.4
@@ -24,7 +25,7 @@ dependencies:
     sdk: flutter
   go_router: ^14.0.1
   http: ^1.2.0
-  intl: ^0.18.0
+  intl: ^0.19.0
   url_launcher: ^6.2.4
 
 dev_dependencies:


### PR DESCRIPTION
## Description

- lcov has gap in switch expressions (see #43 ) that can be fixed by using arrow syntax on the builder
- some flutter upgrades to get in line w/3.22

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
