### PR TITLE
fix: fixing background color after update to 3.22

### DIFF
--- a/packages/blog_ui/lib/src/theme/blog_theme.dart
+++ b/packages/blog_ui/lib/src/theme/blog_theme.dart
@@ -8,6 +8,7 @@ class BlogTheme {
         useMaterial3: true,
         colorScheme: lightColorScheme,
         visualDensity: VisualDensity.adaptivePlatformDensity,
+        scaffoldBackgroundColor: BlogColors.seedLightBackground,
       );
 
   /// Theme data to access dark theme properties in build context.
@@ -15,6 +16,7 @@ class BlogTheme {
         useMaterial3: true,
         colorScheme: darkColorScheme,
         visualDensity: VisualDensity.adaptivePlatformDensity,
+        scaffoldBackgroundColor: BlogColors.seedDarkBackground,
       );
 
   /// Color scheme that is used to generate light theme colors.
@@ -28,7 +30,6 @@ class BlogTheme {
   /// Color scheme that is used to generate dark theme colors.
   static ColorScheme get darkColorScheme => ColorScheme.fromSeed(
         seedColor: BlogColors.seedLightPurple,
-        surface: BlogColors.seedDarkBackground,
         primary: BlogColors.seedTextPrimaryLight,
         secondary: BlogColors.seedTextSecondaryLight,
       );

--- a/packages/blog_ui/test/src/theme/blog_theme_test.dart
+++ b/packages/blog_ui/test/src/theme/blog_theme_test.dart
@@ -9,9 +9,9 @@ void main() {
         expect(BlogTheme.lightThemeData.useMaterial3, isTrue);
       });
 
-      test('surface color is seedLightBackground', () {
+      test('background color is seedLightBackground', () {
         expect(
-          BlogTheme.lightThemeData.colorScheme.surface,
+          BlogTheme.lightThemeData.scaffoldBackgroundColor,
           equals(BlogColors.seedLightBackground),
         );
       });
@@ -43,9 +43,9 @@ void main() {
         expect(BlogTheme.darkThemeData.useMaterial3, isTrue);
       });
 
-      test('surface color is seedDarkBackground', () {
+      test('background color is seedDarkBackground', () {
         expect(
-          BlogTheme.darkThemeData.colorScheme.surface,
+          BlogTheme.darkThemeData.scaffoldBackgroundColor,
           equals(BlogColors.seedDarkBackground),
         );
       });


### PR DESCRIPTION
## Description

- Linter says use `surface` instead of `background` on `ColorScheme`, but `surface` only works on cards
- Using `scaffoldBackgroundColor` instead

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
