### PR TITLE
refactor: change html to widget package

### DIFF
--- a/lib/blog_detail/view/blog_detail_page.dart
+++ b/lib/blog_detail/view/blog_detail_page.dart
@@ -60,9 +60,10 @@ class BlogDetailView extends StatelessWidget {
             title: detail.title,
             authorImage: detail.author.profileImage,
             featuredImage: detail.featuredImage,
-            onLinkTap: (url, attributes, element) => context
-                .read<BlogDetailBloc>()
-                .add(BlogLinkClicked(url: url ?? '')),
+            onTapUrl: (url) {
+              context.read<BlogDetailBloc>().add(BlogLinkClicked(url: url));
+              return true;
+            },
           )
       },
     );

--- a/packages/blog_ui/gallery/devtools_options.yaml
+++ b/packages/blog_ui/gallery/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/packages/blog_ui/gallery/lib/directories/custom/components/blog_detail_content.dart
+++ b/packages/blog_ui/gallery/lib/directories/custom/components/blog_detail_content.dart
@@ -48,13 +48,6 @@ const htmlBody = '''
 <p>Inline <code>code sample</code> example.</p>
 <p> Inline <em>italic</em> and <strong>bold</strong> text.</p>
 <p>Here's a helpful walkthrough of our Blog Engine solution.</p>
-<p><!-- Outer Div sets maximum width for iframe on extra wide screens --></p>
-<div style="max-width: 800px; height: auto; margin: auto;">
-    <!-- Inner div allows for responsive iframe scaling, including on mobile -->
-    <div style="position: relative; padding-bottom: 56.25%; padding-top: 35px; height: 0; overflow: hidden; margin: auto;">
-        <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 9999;" src="https://www.youtube.com/embed/0dJbHy2XqoY" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="allowfullscreen"></iframe>
-    </div>
-</div>
 <p><br><a href="/demo/blog-engine-why-our-blog-engine/">https://buttercms.com/demo/blog-engine-why-our-blog-engine/</a></p>
 <p></p>
 <p></p>

--- a/packages/blog_ui/gallery/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/blog_ui/gallery/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/packages/blog_ui/gallery/linux/flutter/generated_plugins.cmake
+++ b/packages/blog_ui/gallery/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/blog_ui/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/blog_ui/gallery/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,22 @@
 import FlutterMacOS
 import Foundation
 
+import audio_session
+import just_audio
+import package_info_plus
 import path_provider_foundation
+import sqflite
+import url_launcher_macos
+import video_player_avfoundation
+import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
+  WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/packages/blog_ui/gallery/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/blog_ui/gallery/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/packages/blog_ui/gallery/windows/flutter/generated_plugins.cmake
+++ b/packages/blog_ui/gallery/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/blog_ui/lib/blog_ui.dart
+++ b/packages/blog_ui/lib/blog_ui.dart
@@ -1,5 +1,6 @@
 /// A Very Good Project created by Very Good CLI.
 library blog_ui;
 
+export 'src/extensions/extensions.dart';
 export 'src/theme/theme.dart';
 export 'src/widgets/widgets.dart';

--- a/packages/blog_ui/lib/src/extensions/build_context_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/build_context_extension.dart
@@ -6,7 +6,7 @@ import 'package:html/dom.dart' as dom;
 /// Extension on BuildContext for rendering styles in Html widgets.
 extension BuildContextExt on BuildContext {
   /// Builder to convert theme data into CSS styles for HTML content.
-  /// NOTE: as of v0.15.0 of flutter_widget_from_html, <iframe> elements
+  /// NOTE: as of v0.15.0 of flutter_widget_from_html, iframe elements
   /// cannot be rendered:
   /// https://github.com/daohoangson/flutter_widget_from_html/issues/1245
   Map<String, String>? styleBuilder(dom.Element element) {

--- a/packages/blog_ui/lib/src/extensions/build_context_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/build_context_extension.dart
@@ -1,0 +1,70 @@
+import 'package:blog_ui/blog_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:html/dom.dart' as dom;
+
+/// Extension on BuildContext for rendering styles in Html widgets.
+extension BuildContextExt on BuildContext {
+  /// Builder to convert theme data into CSS styles for HTML content.
+  /// NOTE: as of v0.15.0 of flutter_widget_from_html, <iframe> elements
+  /// cannot be rendered:
+  /// https://github.com/daohoangson/flutter_widget_from_html/issues/1245
+  Map<String, String>? styleBuilder(dom.Element element) {
+    final el = element.localName
+        ?.replaceAll(RegExp('<html'), '')
+        .replaceAll(RegExp('>'), '');
+    final theme = Theme.of(this);
+
+    if (el == 'a') {
+      return {
+        'color': theme.colorScheme.secondary.toHex(),
+        ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
+      };
+    } else if (el == 'code') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...GoogleFonts.robotoMono().toStyleMap(),
+      };
+    } else if (el == 'div') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+      };
+    } else if (el == 'figcaption') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.footerTextStyle.toStyleMap(),
+      };
+    } else if (el == 'h1') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.headerTextStyle.toStyleMap(),
+      };
+    } else if (el == 'h2') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.headerSubtitleTextStyle.toStyleMap(),
+      };
+    } else if (el == 'h3') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.cardTitle.toStyleMap(),
+      };
+    } else if (el == 'li') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+      };
+    } else if (el == 'p') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
+      };
+    } else if (el == 'pre') {
+      return {
+        'background-color': theme.colorScheme.primaryContainer.toHex(),
+        'padding': '16px',
+      };
+    }
+
+    return null;
+  }
+}

--- a/packages/blog_ui/lib/src/extensions/color_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/color_extension.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+/// Extension on Color for rendering content in Html widgets.
+extension ColorExt on Color {
+  /// Parses the hex string from a [Color].
+  String toHex() {
+    return '#${value.toRadixString(16).substring(2)}';
+  }
+}

--- a/packages/blog_ui/lib/src/extensions/color_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/color_extension.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Extension on Color for rendering content in Html widgets.
-extension ColorExt on Color {
+extension ColorExtension on Color {
   /// Parses the hex string from a [Color].
   String toHex() {
     return '#${value.toRadixString(16).substring(2)}';

--- a/packages/blog_ui/lib/src/extensions/extensions.dart
+++ b/packages/blog_ui/lib/src/extensions/extensions.dart
@@ -1,0 +1,3 @@
+export 'build_context_extension.dart';
+export 'color_extension.dart';
+export 'text_style_extension.dart';

--- a/packages/blog_ui/lib/src/extensions/extensions.dart
+++ b/packages/blog_ui/lib/src/extensions/extensions.dart
@@ -1,3 +1,3 @@
-export 'build_context_extension.dart';
 export 'color_extension.dart';
 export 'text_style_extension.dart';
+export 'theme_data_extension.dart';

--- a/packages/blog_ui/lib/src/extensions/text_style_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/text_style_extension.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+/// Extension on [TextStyle] to facilitate converting theme data
+/// to HTML/CSS styling.
+extension TextStyleExt on TextStyle {
+  /// Convert elements of a [TextStyle] to a [Map] of
+  /// CSS properties.
+  Map<String, String> toStyleMap() {
+    final map = <String, String>{};
+
+    if (fontSize != null) {
+      map['font-size'] = '${fontSize}px';
+    }
+
+    if (fontStyle != null) {
+      map['font-style'] = fontStyle!.toString();
+    }
+
+    if (fontWeight != null) {
+      map['font-weight'] = fontWeight!.toString();
+    }
+
+    if (fontFamily != null) {
+      map['font-family'] = fontFamily!;
+    }
+
+    return map;
+  }
+}

--- a/packages/blog_ui/lib/src/extensions/text_style_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/text_style_extension.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 /// Extension on [TextStyle] to facilitate converting theme data
 /// to HTML/CSS styling.
-extension TextStyleExt on TextStyle {
+extension TextStyleExtension on TextStyle {
   /// Convert elements of a [TextStyle] to a [Map] of
   /// CSS properties.
   Map<String, String> toStyleMap() {
@@ -13,11 +13,11 @@ extension TextStyleExt on TextStyle {
     }
 
     if (fontStyle != null) {
-      map['font-style'] = fontStyle!.toString();
+      map['font-style'] = fontStyle!.name.toLowerCase();
     }
 
     if (fontWeight != null) {
-      map['font-weight'] = fontWeight!.toString();
+      map['font-weight'] = fontWeight!.value.toString();
     }
 
     if (fontFamily != null) {

--- a/packages/blog_ui/lib/src/extensions/theme_data_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/theme_data_extension.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:html/dom.dart' as dom;
 
-/// Extension on BuildContext for rendering styles in Html widgets.
-extension BuildContextExt on BuildContext {
+/// Extension on ThemeData for rendering styles in Html widgets.
+extension ThemeExt on ThemeData {
   /// Builder to convert theme data into CSS styles for HTML content.
   /// NOTE: as of v0.15.0 of flutter_widget_from_html, iframe elements
   /// cannot be rendered:
@@ -13,54 +13,53 @@ extension BuildContextExt on BuildContext {
     final el = element.localName
         ?.replaceAll(RegExp('<html'), '')
         .replaceAll(RegExp('>'), '');
-    final theme = Theme.of(this);
 
     if (el == 'a') {
       return {
-        'color': theme.colorScheme.secondary.toHex(),
+        'color': colorScheme.secondary.toHex(),
         ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
       };
     } else if (el == 'code') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
         ...GoogleFonts.robotoMono().toStyleMap(),
       };
     } else if (el == 'div') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
       };
     } else if (el == 'figcaption') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
         ...BlogTextStyles.footerTextStyle.toStyleMap(),
       };
     } else if (el == 'h1') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
         ...BlogTextStyles.headerTextStyle.toStyleMap(),
       };
     } else if (el == 'h2') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
         ...BlogTextStyles.headerSubtitleTextStyle.toStyleMap(),
       };
     } else if (el == 'h3') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
         ...BlogTextStyles.cardTitle.toStyleMap(),
       };
     } else if (el == 'li') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
       };
     } else if (el == 'p') {
       return {
-        'color': theme.colorScheme.primary.toHex(),
+        'color': colorScheme.primary.toHex(),
         ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
       };
     } else if (el == 'pre') {
       return {
-        'background-color': theme.colorScheme.primaryContainer.toHex(),
+        'background-color': colorScheme.primaryContainer.toHex(),
         'padding': '16px',
       };
     }

--- a/packages/blog_ui/lib/src/extensions/theme_data_extension.dart
+++ b/packages/blog_ui/lib/src/extensions/theme_data_extension.dart
@@ -4,7 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:html/dom.dart' as dom;
 
 /// Extension on ThemeData for rendering styles in Html widgets.
-extension ThemeExt on ThemeData {
+extension ThemeExtension on ThemeData {
   /// Builder to convert theme data into CSS styles for HTML content.
   /// NOTE: as of v0.15.0 of flutter_widget_from_html, iframe elements
   /// cannot be rendered:

--- a/packages/blog_ui/lib/src/theme/blog_colors.dart
+++ b/packages/blog_ui/lib/src/theme/blog_colors.dart
@@ -18,6 +18,9 @@ abstract class BlogColors {
   /// Seed purple color for the UI.
   static const Color seedPurple = Color(0xFF6F4180);
 
+  /// Seed medium purple color for the UI.
+  static const Color seedMediumPurple = Color(0xFF9C6BA6);
+
   /// Seed light purple color for the UI.
   static const Color seedLightPurple = Color(0xFFD8B3E6);
 

--- a/packages/blog_ui/lib/src/theme/blog_colors.dart
+++ b/packages/blog_ui/lib/src/theme/blog_colors.dart
@@ -5,8 +5,15 @@ abstract class BlogColors {
   /// Seed light background color for the UI.
   static const Color seedLightBackground = Color(0xFFCFCFCF);
 
+  /// Seed light primary container color for the UI.
+  static const Color seedLightPrimaryContainer = Color(0xFFA6A6A6);
+
   /// Seed dark background color for the UI.
   static const Color seedDarkBackground = Color(0xFF333233);
+
+  /// Seed dark primary container color for the UI.
+  /// Seed dark primary container color for the UI.
+  static const Color seedDarkPrimaryContainer = Color(0xFF4D4D4D);
 
   /// Seed purple color for the UI.
   static const Color seedPurple = Color(0xFF6F4180);

--- a/packages/blog_ui/lib/src/theme/blog_theme.dart
+++ b/packages/blog_ui/lib/src/theme/blog_theme.dart
@@ -25,6 +25,7 @@ class BlogTheme {
         primary: BlogColors.seedTextPrimaryDark,
         primaryContainer: BlogColors.seedLightPrimaryContainer,
         secondary: BlogColors.seedTextSecondaryDark,
+        secondaryContainer: BlogColors.seedMediumPurple,
       );
 
   /// Color scheme that is used to generate dark theme colors.
@@ -33,5 +34,6 @@ class BlogTheme {
         primary: BlogColors.seedTextPrimaryLight,
         secondary: BlogColors.seedTextSecondaryLight,
         primaryContainer: BlogColors.seedDarkPrimaryContainer,
+        secondaryContainer: BlogColors.seedLightPurple,
       );
 }

--- a/packages/blog_ui/lib/src/theme/blog_theme.dart
+++ b/packages/blog_ui/lib/src/theme/blog_theme.dart
@@ -22,8 +22,8 @@ class BlogTheme {
   /// Color scheme that is used to generate light theme colors.
   static ColorScheme get lightColorScheme => ColorScheme.fromSeed(
         seedColor: BlogColors.seedPurple,
-        surface: BlogColors.seedLightBackground,
         primary: BlogColors.seedTextPrimaryDark,
+        primaryContainer: BlogColors.seedLightPrimaryContainer,
         secondary: BlogColors.seedTextSecondaryDark,
       );
 
@@ -32,5 +32,6 @@ class BlogTheme {
         seedColor: BlogColors.seedLightPurple,
         primary: BlogColors.seedTextPrimaryLight,
         secondary: BlogColors.seedTextSecondaryLight,
+        primaryContainer: BlogColors.seedDarkPrimaryContainer,
       );
 }

--- a/packages/blog_ui/lib/src/widgets/blog_card.dart
+++ b/packages/blog_ui/lib/src/widgets/blog_card.dart
@@ -42,7 +42,7 @@ class BlogCard extends StatelessWidget {
         elevation: 5,
         clipBehavior: Clip.hardEdge,
         margin: BlogSpacing.bottomMargin,
-        color: theme.colorScheme.primaryContainer,
+        color: theme.colorScheme.secondaryContainer,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,

--- a/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
+++ b/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
@@ -102,7 +102,7 @@ class BlogDetailContent extends StatelessWidget {
                 Expanded(
                   child: HtmlWidget(
                     body,
-                    //customStylesBuilder: (element) => styles(theme),
+                    customStylesBuilder: context.styleBuilder,
                     onTapUrl: onTapUrl,
                   ),
                 ),
@@ -112,6 +112,97 @@ class BlogDetailContent extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+extension BuildContextExt on BuildContext {
+  Map<String, String>? styleBuilder(dom.Element element) {
+    final el = element.localName
+        ?.replaceAll(RegExp('<html'), '')
+        .replaceAll(RegExp('>'), '');
+    final theme = Theme.of(this);
+
+    if (el == 'a') {
+      return {
+        'color': theme.colorScheme.secondary.toHex(),
+        ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
+      };
+    } else if (el == 'code') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...GoogleFonts.robotoMono().toStyleMap(),
+      };
+    } else if (el == 'div') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+      };
+    } else if (el == 'figcaption') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.footerTextStyle.toStyleMap(),
+      };
+    } else if (el == 'h1') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.headerTextStyle.toStyleMap(),
+      };
+    } else if (el == 'h2') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.headerSubtitleTextStyle.toStyleMap(),
+      };
+    } else if (el == 'h3') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.cardTitle.toStyleMap(),
+      };
+    } else if (el == 'li') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+      };
+    } else if (el == 'p') {
+      return {
+        'color': theme.colorScheme.primary.toHex(),
+        ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
+      };
+    } else if (el == 'pre') {
+      return {
+        'background-color': theme.colorScheme.primaryContainer.toHex(),
+        'padding': '16px',
+      };
+    }
+
+    return null;
+  }
+}
+
+extension ColorExt on Color {
+  String toHex() {
+    return '#${value.toRadixString(16).substring(2)}';
+  }
+}
+
+extension TextStyleExt on TextStyle {
+  Map<String, String> toStyleMap() {
+    final map = <String, String>{};
+
+    if (fontSize != null) {
+      map['font-size'] = '${fontSize}px';
+    }
+
+    if (fontStyle != null) {
+      map['font-style'] = fontStyle!.toString();
+    }
+
+    if (fontWeight != null) {
+      map['font-weight'] = fontWeight!.toString();
+    }
+
+    if (fontFamily != null) {
+      map['font-family'] = fontFamily!;
+    }
+
+    return map;
   }
 }
 

--- a/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
+++ b/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:blog_ui/blog_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:html/dom.dart' as dom;
 import 'package:intl/intl.dart';
@@ -19,6 +23,7 @@ class BlogDetailContent extends StatelessWidget {
     this.authorImage,
     this.featuredImage,
     this.onLinkTap,
+    this.onTapUrl,
     super.key,
   });
 
@@ -45,6 +50,9 @@ class BlogDetailContent extends StatelessWidget {
 
   /// A callback function that is called when a link in the HTML body is tapped.
   final void Function(String?, Map<String, String>, dom.Element?)? onLinkTap;
+
+  /// A callback function that is called when a link in the HTML body is tapped.
+  final FutureOr<bool> Function(String)? onTapUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -89,10 +97,16 @@ class BlogDetailContent extends StatelessWidget {
                 color: theme.colorScheme.primary,
               ),
             ),
-            Html(
-              data: body,
-              style: styles(theme),
-              onLinkTap: onLinkTap,
+            Row(
+              children: [
+                Expanded(
+                  child: HtmlWidget(
+                    body,
+                    //customStylesBuilder: (element) => styles(theme),
+                    onTapUrl: onTapUrl,
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
+++ b/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
@@ -2,11 +2,7 @@ import 'dart:async';
 
 import 'package:blog_ui/blog_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:html/dom.dart' as dom;
 import 'package:intl/intl.dart';
 
 /// {@template blog_detail_content}
@@ -22,7 +18,6 @@ class BlogDetailContent extends StatelessWidget {
     required this.title,
     this.authorImage,
     this.featuredImage,
-    this.onLinkTap,
     this.onTapUrl,
     super.key,
   });
@@ -47,9 +42,6 @@ class BlogDetailContent extends StatelessWidget {
 
   /// The URL of the featured image of the blog post.
   final String? featuredImage;
-
-  /// A callback function that is called when a link in the HTML body is tapped.
-  final void Function(String?, Map<String, String>, dom.Element?)? onLinkTap;
 
   /// A callback function that is called when a link in the HTML body is tapped.
   final FutureOr<bool> Function(String)? onTapUrl;
@@ -113,155 +105,4 @@ class BlogDetailContent extends StatelessWidget {
       ),
     );
   }
-}
-
-extension BuildContextExt on BuildContext {
-  Map<String, String>? styleBuilder(dom.Element element) {
-    final el = element.localName
-        ?.replaceAll(RegExp('<html'), '')
-        .replaceAll(RegExp('>'), '');
-    final theme = Theme.of(this);
-
-    if (el == 'a') {
-      return {
-        'color': theme.colorScheme.secondary.toHex(),
-        ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
-      };
-    } else if (el == 'code') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-        ...GoogleFonts.robotoMono().toStyleMap(),
-      };
-    } else if (el == 'div') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-      };
-    } else if (el == 'figcaption') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-        ...BlogTextStyles.footerTextStyle.toStyleMap(),
-      };
-    } else if (el == 'h1') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-        ...BlogTextStyles.headerTextStyle.toStyleMap(),
-      };
-    } else if (el == 'h2') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-        ...BlogTextStyles.headerSubtitleTextStyle.toStyleMap(),
-      };
-    } else if (el == 'h3') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-        ...BlogTextStyles.cardTitle.toStyleMap(),
-      };
-    } else if (el == 'li') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-      };
-    } else if (el == 'p') {
-      return {
-        'color': theme.colorScheme.primary.toHex(),
-        ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
-      };
-    } else if (el == 'pre') {
-      return {
-        'background-color': theme.colorScheme.primaryContainer.toHex(),
-        'padding': '16px',
-      };
-    }
-
-    return null;
-  }
-}
-
-extension ColorExt on Color {
-  String toHex() {
-    return '#${value.toRadixString(16).substring(2)}';
-  }
-}
-
-extension TextStyleExt on TextStyle {
-  Map<String, String> toStyleMap() {
-    final map = <String, String>{};
-
-    if (fontSize != null) {
-      map['font-size'] = '${fontSize}px';
-    }
-
-    if (fontStyle != null) {
-      map['font-style'] = fontStyle!.toString();
-    }
-
-    if (fontWeight != null) {
-      map['font-weight'] = fontWeight!.toString();
-    }
-
-    if (fontFamily != null) {
-      map['font-family'] = fontFamily!;
-    }
-
-    return map;
-  }
-}
-
-/// A function that returns a [Map] of styles to be defined for
-/// the HTML body.
-Map<String, Style> styles(ThemeData theme) {
-  Style style({
-    Color? backgroundColor,
-    Color? color,
-    TextStyle? textStyle,
-    HtmlPaddings? padding,
-  }) {
-    return Style(
-      backgroundColor: backgroundColor,
-      color: color,
-      fontSize:
-          textStyle?.fontSize != null ? FontSize(textStyle!.fontSize!) : null,
-      fontStyle: textStyle?.fontStyle,
-      fontWeight: textStyle?.fontWeight,
-      fontFamily: textStyle?.fontFamily,
-      padding: padding,
-    );
-  }
-
-  return {
-    'a': style(
-      color: theme.colorScheme.secondary,
-      textStyle: BlogTextStyles.detailBodyTextStyle,
-    ),
-    'code': style(
-      backgroundColor: Colors.transparent,
-      color: theme.colorScheme.primary,
-      textStyle: GoogleFonts.robotoMono(),
-    ),
-    'div': style(color: theme.colorScheme.primary),
-    'figcaption': style(
-      color: theme.colorScheme.primary,
-      textStyle: BlogTextStyles.footerTextStyle,
-    ),
-    'h1': style(
-      color: theme.colorScheme.primary,
-      textStyle: BlogTextStyles.headerTextStyle,
-    ),
-    'h2': style(
-      color: theme.colorScheme.primary,
-      textStyle: BlogTextStyles.headerSubtitleTextStyle,
-    ),
-    'h3': style(
-      color: theme.colorScheme.primary,
-      textStyle: BlogTextStyles.cardTitle,
-    ),
-    'li': style(color: theme.colorScheme.primary),
-    'p': style(
-      color: theme.colorScheme.primary,
-      textStyle: BlogTextStyles.detailBodyTextStyle,
-    ),
-    'pre': style(
-      backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
-      padding: HtmlPaddings.all(16),
-    ),
-  };
 }

--- a/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
+++ b/packages/blog_ui/lib/src/widgets/blog_detail_content.dart
@@ -94,8 +94,9 @@ class BlogDetailContent extends StatelessWidget {
                 Expanded(
                   child: HtmlWidget(
                     body,
-                    customStylesBuilder: context.styleBuilder,
+                    customStylesBuilder: theme.styleBuilder,
                     onTapUrl: onTapUrl,
+                    rebuildTriggers: [theme],
                   ),
                 ),
               ],

--- a/packages/blog_ui/pubspec.yaml
+++ b/packages/blog_ui/pubspec.yaml
@@ -10,12 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # Forking flutter_html because of bug that breaks on lower versions of ios
-  # https://github.com/Sub6Resources/flutter_html/issues/1314#issuecomment-1635802042
-  flutter_html: 
-    git: 
-      url: https://github.com/stefanhk31/flutter_html.git
-      ref: hotfix/incompat-regexp
   flutter_widget_from_html: ^0.15.0
   google_fonts: ^6.2.1
   html: ^0.15.4

--- a/packages/blog_ui/pubspec.yaml
+++ b/packages/blog_ui/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
     git: 
       url: https://github.com/stefanhk31/flutter_html.git
       ref: hotfix/incompat-regexp
+  flutter_widget_from_html: ^0.15.0
   google_fonts: ^6.2.1
   html: ^0.15.4
   intl: ^0.19.0

--- a/packages/blog_ui/test/src/extensions/color_extension_test.dart
+++ b/packages/blog_ui/test/src/extensions/color_extension_test.dart
@@ -1,0 +1,14 @@
+import 'package:blog_ui/blog_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ColorExtension', () {
+    group('toHex', () {
+      test('returns pound sign plus the correct hex value ', () {
+        const color = Color(0xFF00FF00);
+        expect(color.toHex(), '#00ff00');
+      });
+    });
+  });
+}

--- a/packages/blog_ui/test/src/extensions/text_style_extension_test.dart
+++ b/packages/blog_ui/test/src/extensions/text_style_extension_test.dart
@@ -1,0 +1,28 @@
+import 'package:blog_ui/blog_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TextStyleExtension', () {
+    group('toStyleMap', () {
+      test('returns a map of CSS properties', () {
+        const style = TextStyle(
+          fontSize: 16,
+          fontStyle: FontStyle.italic,
+          fontWeight: FontWeight.bold,
+          fontFamily: 'Roboto',
+        );
+
+        expect(
+          style.toStyleMap(),
+          equals({
+            'font-size': '16.0px',
+            'font-style': 'italic',
+            'font-weight': '700',
+            'font-family': 'Roboto',
+          }),
+        );
+      });
+    });
+  });
+}

--- a/packages/blog_ui/test/src/extensions/theme_data_extension_test.dart
+++ b/packages/blog_ui/test/src/extensions/theme_data_extension_test.dart
@@ -1,0 +1,106 @@
+import 'package:blog_ui/blog_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:html/dom.dart' as dom;
+
+void main() {
+  group('ThemeDataExtension', () {
+    group('styleBuilder', () {
+      final htmlElementVariants = ValueVariant({
+        'a',
+        'code',
+        'div',
+        'figcaption',
+        'h1',
+        'h2',
+        'h3',
+        'li',
+        'p',
+        'pre',
+      });
+
+      testWidgets(
+        'returns correct style for HTML element',
+        (tester) async {
+          final theme = BlogTheme.lightThemeData;
+          final el = htmlElementVariants.currentValue ?? 'a';
+          final element = dom.Element.html(
+            '<$el>',
+          );
+
+          Map<String, String>? expectedStyle(String el) {
+            if (el == 'a') {
+              return {
+                'color': theme.colorScheme.secondary.toHex(),
+                ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
+              };
+            } else if (el == 'code') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+                ...GoogleFonts.robotoMono().toStyleMap(),
+              };
+            } else if (el == 'div') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+              };
+            } else if (el == 'figcaption') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+                ...BlogTextStyles.footerTextStyle.toStyleMap(),
+              };
+            } else if (el == 'h1') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+                ...BlogTextStyles.headerTextStyle.toStyleMap(),
+              };
+            } else if (el == 'h2') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+                ...BlogTextStyles.headerSubtitleTextStyle.toStyleMap(),
+              };
+            } else if (el == 'h3') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+                ...BlogTextStyles.cardTitle.toStyleMap(),
+              };
+            } else if (el == 'li') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+              };
+            } else if (el == 'p') {
+              return {
+                'color': theme.colorScheme.primary.toHex(),
+                ...BlogTextStyles.detailBodyTextStyle.toStyleMap(),
+              };
+            } else if (el == 'pre') {
+              return {
+                'background-color': theme.colorScheme.primaryContainer.toHex(),
+                'padding': '16px',
+              };
+            }
+
+            return null;
+          }
+
+          expect(
+            theme.styleBuilder(element),
+            equals(
+              expectedStyle(el),
+            ),
+          );
+        },
+        variant: htmlElementVariants,
+      );
+
+      test('returns null for unknown HTML element', () {
+        final theme = BlogTheme.lightThemeData;
+        final element = dom.Element.html('<unknown>');
+
+        expect(
+          theme.styleBuilder(element),
+          isNull,
+        );
+      });
+    });
+  });
+}

--- a/packages/blog_ui/test/src/widgets/blog_detail_content_test.dart
+++ b/packages/blog_ui/test/src/widgets/blog_detail_content_test.dart
@@ -52,8 +52,9 @@ void main() {
           published: DateTime.now(),
           slug: slug,
           title: title,
-          onLinkTap: (link, _, __) {
+          onTapUrl: (link) {
             tappedLink = link;
+            return true;
           },
         ),
       );
@@ -61,7 +62,7 @@ void main() {
       final widget =
           tester.widget<BlogDetailContent>(find.byType(BlogDetailContent));
 
-      widget.onLinkTap?.call(testLink, <String, String>{}, null);
+      widget.onTapUrl?.call(testLink);
 
       expect(tappedLink, equals(testLink));
     });

--- a/test/blog_detail/view/blog_detail_page_test.dart
+++ b/test/blog_detail/view/blog_detail_page_test.dart
@@ -102,7 +102,7 @@ void main() {
 
         final content =
             tester.widget<BlogDetailContent>(find.byType(BlogDetailContent));
-        content.onLinkTap?.call('https://url', {}, null);
+        content.onTapUrl?.call('https://url');
 
         await tester.pumpAndSettle();
         verify(() => bloc.add(const BlogLinkClicked(url: 'https://url')))


### PR DESCRIPTION
## Description

- Changing bloc detail from using [flutter_html](https://pub.dev/packages/flutter_html) to [flutter_widget_from_html](https://pub.dev/packages/flutter_widget_from_html). 
- `flutter_widget_from_html` has more recent and regular attention from package maintainer
- Updating generation of CSS styles to accommodate new package
- Some tweaks/refactors of the `blog_ui`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
